### PR TITLE
Fix typo in first line

### DIFF
--- a/0x21_0x23_modern_stack0/brute_cookie.c
+++ b/0x21_0x23_modern_stack0/brute_cookie.c
@@ -1,4 +1,4 @@
-nclude <unistd.h>
+#include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <signal.h>


### PR DESCRIPTION
I think you forgot to change vim to insert mode so the first 2 characters "#i" got truncated.